### PR TITLE
Fix Time singleton newline handling

### DIFF
--- a/Time.qml
+++ b/Time.qml
@@ -14,7 +14,7 @@ Singleton {
     running: true
 
     stdout: StdioCollector {
-      onStreamFinished: root.time = this.text
+      onStreamFinished: root.time = this.text.trim()
     }
   }
 


### PR DESCRIPTION
## Summary
- trim trailing newline from the `date` command output in `Time.qml`
- ensure file has final newline

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6870996b23f8832d818bdfd7e289f6a0